### PR TITLE
fix: changed String status to Enum type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*

--- a/src/main/java/Chamado.java
+++ b/src/main/java/Chamado.java
@@ -2,6 +2,9 @@ import java.util.Collection;
 import java.util.Date;
 
 public class Chamado {
+	public enum Status{
+		ABERTO, ANDAMENTO, CONCLUIDO;
+	}
 
 	private Funcionario funcionario;
 
@@ -11,7 +14,7 @@ public class Chamado {
 
 	private Date dataAbertura;
 
-	private String status;
+	private Status status;
 
 	private String textoResolucao;
 
@@ -23,7 +26,7 @@ public class Chamado {
 		this.equipamento = equipamento;
 		this.dataSolicitacao = dataSolicitacao;
 		this.dataAbertura = dataAbertura;
-		this.status = "ABERTO";
+		this.status = Status.ABERTO;
 		this.textoSolicitacao = textoSolicitacao;
 	}
 
@@ -67,12 +70,12 @@ public class Chamado {
 		this.dataAbertura = dataAbertura;
 	}
 
-	public String getStatus()
+	public Status getStatus()
 	{
-		return status;
+		return this.status;
 	}
 
-	public void setStatus(String status)
+	public void setStatus(Status status)
 	{
 		this.status = status;
 	}

--- a/src/main/java/ChamadoManager.java
+++ b/src/main/java/ChamadoManager.java
@@ -50,14 +50,14 @@ public class ChamadoManager {
 		{
 			if (existingChamado.equals(chamado))
 			{
-				if (existingChamado.getStatus().equalsIgnoreCase("ABERTO"))
+				if (existingChamado.getStatus().equals(Chamado.Status.ABERTO))
 				{
-					existingChamado.setStatus("EM ANDAMENTO");
+					existingChamado.setStatus(Chamado.Status.ANDAMENTO);
 					return true;
 				}
-				else if (existingChamado.getStatus().equalsIgnoreCase("EM ANDAMENTO"))
+				else if (existingChamado.getStatus().equals(Chamado.Status.ANDAMENTO))
 				{
-					existingChamado.setStatus("CONCLUIDO");
+					existingChamado.setStatus(Chamado.Status.CONCLUIDO);
 					return true;
 				}
 				else
@@ -96,7 +96,7 @@ public class ChamadoManager {
 
 		for (Chamado chamado : chamados)
 		{
-			if (chamado.getStatus().equalsIgnoreCase(status))
+			if (chamado.getStatus().equals(status))
 			{
 				count++;
 			}


### PR DESCRIPTION
A alteração proposta no código consiste em alterar o tipo do atributo `status` do `Chamado` de `String` para `Enum`. Isso torna o atributo mais seguro, pois agora ele pode ter apenas valores predefinidos e evita erros de digitação ou de valores inválidos. 

Além disso, o arquivo `.gitignore` foi adicionado.